### PR TITLE
Allow key to fallback to tag

### DIFF
--- a/lib/fluent/plugin/out_dogstatsd.rb
+++ b/lib/fluent/plugin/out_dogstatsd.rb
@@ -5,6 +5,7 @@ module Fluent
     config_param :host, :string, :default => nil
     config_param :port, :integer, :default => nil
     config_param :use_tag_as_key, :bool, :default => false
+    config_param :use_tag_as_key_if_missing, :bool, :default => false
     config_param :flat_tags, :bool, :default => false
     config_param :flat_tag, :bool, :default => false # obsolete
     config_param :metric_type, :string, :default => nil
@@ -44,6 +45,10 @@ module Fluent
                 else
                   record.delete('key')
                 end
+
+          if !key && @use_tag_as_key_if_missing
+            key = tag
+          end
 
           unless key
             log.warn "'key' is not specified. skip this record:", tag: tag

--- a/test/plugin/test_out_dogstatsd.rb
+++ b/test/plugin/test_out_dogstatsd.rb
@@ -137,21 +137,21 @@ use_tag_as_key_if_missing true
 sample_rate .5
     EOC
 
-    d.emit({'type' => 'increment'}, Time.now.to_i)
+    d.emit({'type' => 'increment', 'key' => 'tag'}, Time.now.to_i)
     d.run
 
     assert_equal(d.instance.statsd.messages, [
-      [:increment, 'dogstatsd.tag', {sample_rate: 0.5}],
+      [:increment, 'tag', {sample_rate: 0.5}],
     ])
   end
 
   def test_sample_rate
     d = create_driver
-    d.emit({'type' => 'increment', 'sample_rate' => 0.5}, Time.now.to_i)
+    d.emit({'type' => 'increment', 'sample_rate' => 0.5, 'key' => 'tag'}, Time.now.to_i)
     d.run
 
     assert_equal(d.instance.statsd.messages, [
-      [:increment, 'dogstatsd.tag', {sample_rate: 0.5}],
+      [:increment, 'tag', {sample_rate: 0.5}],
     ])
   end
 

--- a/test/plugin/test_out_dogstatsd.rb
+++ b/test/plugin/test_out_dogstatsd.rb
@@ -107,6 +107,20 @@ use_tag_as_key true
     ])
   end
 
+  def test_use_tag_as_key_fallback
+    d = create_driver(<<-EOC)
+#{default_config}
+use_tag_as_key_if_missing true
+    EOC
+
+    d.emit({'type' => 'increment'}, Time.now.to_i)
+    d.run
+
+    assert_equal(d.instance.statsd.messages, [
+      [:increment, 'dogstatsd.tag', {}],
+    ])
+  end
+
   def test_tags
     d = create_driver
     d.emit({'type' => 'increment', 'key' => 'hello.world', 'tags' => {'key' => 'value'}}, Time.now.to_i)


### PR DESCRIPTION
We're using a generic `datadog` match to send all of our metrics:

```
<match dogstatsd.**>
  type dogstatsd
</match>
```

Instead of separating out match blocks for each tag we know we want to use `use_tag_as_key`, it'd be nice if the plugin just falls back on the tag if no key is provided.