### PR TITLE
Add alert_type

### DIFF
--- a/lib/fluent/plugin/out_dogstatsd.rb
+++ b/lib/fluent/plugin/out_dogstatsd.rb
@@ -78,11 +78,6 @@ module Fluent
             end
           end
 
-          alert_type = record['alert_type']
-          if alert_type
-            options[:alert_type] = alert_type
-          end
-
           case type
           when 'increment'
             s.increment(key, options)
@@ -99,6 +94,7 @@ module Fluent
           when 'set'
             s.set(key, value, options)
           when 'event'
+            options[:alert_type] = record['alert_type']
             s.event(title, text, options)
           when nil
             log.warn "type is not provided (You can provide type via `metric_type` in config or `type` field in a record."

--- a/lib/fluent/plugin/out_dogstatsd.rb
+++ b/lib/fluent/plugin/out_dogstatsd.rb
@@ -78,6 +78,11 @@ module Fluent
             end
           end
 
+          alert_type = record['alert_type']
+          if alert_type
+            options[:alert_type] = alert_type
+          end
+
           case type
           when 'increment'
             s.increment(key, options)


### PR DESCRIPTION
Hi!

I want to use `alert_type` option when type is event.
http://docs.datadoghq.com/guides/dogstatsd/#events
but currently this plugin don't support it, so request it.

I think more better way is that plugin allow other optional parameters(like `hostname`, `aggregation_key` ...).
If you think it is better too, I will do this.