### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-dogstatsd.gemspec
+++ b/fluent-plugin-dogstatsd.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd"
+  spec.add_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_dependency "dogstatsd-ruby", "~> 1.4.1"
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/lib/fluent/plugin/out_dogstatsd.rb
+++ b/lib/fluent/plugin/out_dogstatsd.rb
@@ -1,3 +1,4 @@
+require 'statsd' # dogstatsd-ruby
 require 'fluent/plugin/output'
 
 module Fluent::Plugin
@@ -31,8 +32,6 @@ module Fluent::Plugin
 
     def initialize
       super
-
-      require 'statsd' # dogstatsd-ruby
     end
 
     def configure(conf)

--- a/lib/fluent/plugin/out_dogstatsd.rb
+++ b/lib/fluent/plugin/out_dogstatsd.rb
@@ -24,10 +24,6 @@ module Fluent::Plugin
       config_set_default :chunk_keys, ['tag']
     end
 
-    unless method_defined?(:log)
-      define_method(:log) { $log }
-    end
-
     attr_accessor :statsd
 
     def configure(conf)

--- a/lib/fluent/plugin/out_dogstatsd.rb
+++ b/lib/fluent/plugin/out_dogstatsd.rb
@@ -30,10 +30,6 @@ module Fluent::Plugin
 
     attr_accessor :statsd
 
-    def initialize
-      super
-    end
-
     def configure(conf)
       compat_parameters_convert(conf, :buffer)
       super

--- a/test/plugin/test_out_dogstatsd.rb
+++ b/test/plugin/test_out_dogstatsd.rb
@@ -38,6 +38,21 @@ class DogstatsdOutputTest < Test::Unit::TestCase
     assert_equal(12345, d.instance.port)
   end
 
+  test 'lack of tag in chunk_keys' do
+    assert_raise_message(/'tag' in chunk_keys is required./) do
+      create_driver(Fluent::Config::Element.new(
+                      'ROOT', '', {
+                        '@type' => 'dogstatsd',
+                        'host' => 'HOST',
+                        'port' => 12345,
+                      }, [
+                        Fluent::Config::Element.new('buffer', 'mykey', {
+                                                      'chunk_keys' => 'mykey'
+                                                    }, [])
+                      ]))
+    end
+  end
+
   def test_write
     d = create_driver
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,6 @@
 require 'test/unit'
 require 'fluent/test'
+require 'fluent/test/driver/output'
+require 'fluent/test/helpers'
 
+Test::Unit::TestCase.include(Fluent::Test::Helpers)


### PR DESCRIPTION
I've tried to use v0.14 Output plugin API.
This PR contains major update change.
Could you bump up minor version if releasing new version of gem?

Thanks,