### PR TITLE
Additional features to set key name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Supported types are `increment`, `decrement`, `count`, `gauge`, `histogram`, `ti
   # Use tag of fluentd record as key sent to Dogstatsd
   use_tag_as_key false
 
+  # Optionally use a fixed key name for the metric name
+  key haproxy.services.api.num_requests
+
+  # Optionally use dynamic key that's implemented via `Fluent::Plugin::Output#extract_placeholders`
+  # key haproxy.services.${service}.num_requests
+
   # (Treat fields in a record as tags)
   # flat_tags true
 
@@ -77,6 +83,44 @@ Supported types are `increment`, `decrement`, `count`, `gauge`, `histogram`, `ti
   metric_type histogram
   flat_tags true
   use_tag_as_key true
+</match>
+```
+
+```haproxy
+<source>
+  type tail
+  path /var/log/haproxy.requests.log
+  pos_file /var/log/haproxy-requests.log.pos
+  tag haproxy.requests
+  format json
+</source>
+
+<match haproxy.requests>
+  type dogstatsd
+  metric_type histogram
+  key haproxy.services.${service}.response_time
+  value_key response_time
+  <buffer ["tag", "service"]>
+  </buffer>
+</match>
+```
+
+```haproxy
+<source>
+  type tail
+  path /var/log/haproxy.requests.log
+  pos_file /var/log/haproxy-requests.log.pos
+  tag haproxy.requests
+  format json
+</source>
+
+<match haproxy.requests>
+  type dogstatsd
+  metric_type histogram
+  key haproxy.overall.response_time
+  value_key response_time
+  <buffer ["tag"]>
+  </buffer>
 </match>
 ```
 

--- a/fluent-plugin-dogstatsd.gemspec
+++ b/fluent-plugin-dogstatsd.gemspec
@@ -1,11 +1,10 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'fluent/plugin/dogstatsd/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-dogstatsd"
-  spec.version       = Fluent::Plugin::Dogstatsd::VERSION
+  spec.version       = "0.0.7"
   spec.authors       = ["Ryota Arai"]
   spec.email         = ["ryota.arai@gmail.com"]
   spec.summary       = %q{Fluent plugin for Dogstatsd, that is statsd server for Datadog.}

--- a/fluent-plugin-dogstatsd.gemspec
+++ b/fluent-plugin-dogstatsd.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd", '~> 1.0.2'
+  spec.add_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_dependency "dogstatsd-ruby", "~> 3.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/fluent-plugin-dogstatsd.gemspec
+++ b/fluent-plugin-dogstatsd.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fluentd"
-  spec.add_dependency "dogstatsd-ruby", "~> 1.4.1"
+  spec.add_dependency "fluentd", '~> 1.0.2'
+  spec.add_dependency "dogstatsd-ruby", "~> 3.3.0"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/fluent/plugin/dogstatsd.rb
+++ b/lib/fluent/plugin/dogstatsd.rb
@@ -1,9 +1,0 @@
-require "fluent/plugin/dogstatsd/version"
-
-module Fluent
-  module Plugin
-    module Dogstatsd
-      # Your code goes here...
-    end
-  end
-end

--- a/lib/fluent/plugin/dogstatsd/version.rb
+++ b/lib/fluent/plugin/dogstatsd/version.rb
@@ -1,7 +1,0 @@
-module Fluent
-  module Plugin
-    module Dogstatsd
-      VERSION = "0.0.6"
-    end
-  end
-end

--- a/lib/fluent/plugin/out_dogstatsd.rb
+++ b/lib/fluent/plugin/out_dogstatsd.rb
@@ -17,7 +17,7 @@ module Fluent::Plugin
 
     config_section :buffer do
         config_set_default :flush_mode, :immediate
-        config_set_default :chunk_keys, ["tag", "backend_name"]
+        config_set_default :chunk_keys, ["tag"]
     end
 
     unless method_defined?(:log)
@@ -25,6 +25,11 @@ module Fluent::Plugin
     end
 
     attr_accessor :statsd
+
+    def configure(conf)
+      super
+
+    end
 
     def initialize
       super
@@ -42,7 +47,10 @@ module Fluent::Plugin
 
     def write(chunk)
       tag = chunk.metadata.tag
-      key = extract_placeholders(@key, chunk)
+      key = @key
+      if key != nil
+        key = extract_placeholders(key, chunk)
+      end
 
       @statsd.batch do |s|
         chunk.each do |time, record|

--- a/lib/fluent/plugin/out_dogstatsd.rb
+++ b/lib/fluent/plugin/out_dogstatsd.rb
@@ -4,6 +4,8 @@ module Fluent::Plugin
   class DogstatsdOutput < Output
     Fluent::Plugin.register_output('dogstatsd', self)
 
+    helpers :compat_parameters
+
     config_param :host, :string, :default => nil
     config_param :port, :integer, :default => nil
     config_param :key, :string, :default => nil
@@ -16,6 +18,7 @@ module Fluent::Plugin
     config_param :sample_rate, :float, :default => nil
 
     config_section :buffer do
+        config_set_default :@type, "memory"
         config_set_default :flush_mode, :immediate
         config_set_default :chunk_keys, ["tag"]
     end
@@ -28,6 +31,8 @@ module Fluent::Plugin
 
     def configure(conf)
       super
+      compat_parameters_convert(conf, :buffer)
+      raise Fluent::ConfigError, "'tag' in chunk_keys is required." if not @chunk_key_tag
 
     end
 

--- a/lib/fluent/plugin/out_dogstatsd.rb
+++ b/lib/fluent/plugin/out_dogstatsd.rb
@@ -4,6 +4,7 @@ module Fluent
 
     config_param :host, :string, :default => nil
     config_param :port, :integer, :default => nil
+    config_param :key, :string, :default => nil
     config_param :use_tag_as_key, :bool, :default => false
     config_param :use_tag_as_key_if_missing, :bool, :default => false
     config_param :flat_tags, :bool, :default => false
@@ -40,11 +41,15 @@ module Fluent
     def write(chunk)
       @statsd.batch do |s|
         chunk.msgpack_each do |tag, time, record|
-          key = if @use_tag_as_key
-                  tag
-                else
-                  record.delete('key')
-                end
+          key = @key
+
+          if !key
+            key = if @use_tag_as_key
+                tag
+              else
+                record.delete('key')
+              end
+          end
 
           if !key && @use_tag_as_key_if_missing
             key = tag

--- a/test/plugin/test_out_dogstatsd.rb
+++ b/test/plugin/test_out_dogstatsd.rb
@@ -41,16 +41,17 @@ class DogstatsdOutputTest < Test::Unit::TestCase
   def test_write
     d = create_driver
 
-    d.emit({'type' => 'increment', 'key' => 'hello.world1'}, Time.now.to_i)
-    d.emit({'type' => 'increment', 'key' => 'hello.world2'}, Time.now.to_i)
-    d.emit({'type' => 'decrement', 'key' => 'hello.world'}, Time.now.to_i)
-    d.emit({'type' => 'count', 'value' => 10, 'key' => 'hello.world'}, Time.now.to_i)
-    d.emit({'type' => 'gauge', 'value' => 10, 'key' => 'hello.world'}, Time.now.to_i)
-    d.emit({'type' => 'histogram', 'value' => 10, 'key' => 'hello.world'}, Time.now.to_i)
-    d.emit({'type' => 'timing', 'value' => 10, 'key' => 'hello.world'}, Time.now.to_i)
-    d.emit({'type' => 'set', 'value' => 10, 'key' => 'hello.world'}, Time.now.to_i)
-    d.emit({'type' => 'event', 'title' => 'Deploy', 'text' => 'Revision', 'key' => 'hello.world'}, Time.now.to_i)
-    d.run
+    d.run(default_tag: 'test') do
+        d.feed({'type' => 'increment', 'key' => 'hello.world1'})
+        d.feed({'type' => 'increment', 'key' => 'hello.world2'})
+        d.feed({'type' => 'decrement', 'key' => 'hello.world'})
+        d.feed({'type' => 'count', 'value' => 10, 'key' => 'hello.world'})
+        d.feed({'type' => 'gauge', 'value' => 10, 'key' => 'hello.world'})
+        d.feed({'type' => 'histogram', 'value' => 10, 'key' => 'hello.world'})
+        d.feed({'type' => 'timing', 'value' => 10, 'key' => 'hello.world'})
+        d.feed({'type' => 'set', 'value' => 10, 'key' => 'hello.world'})
+        d.feed({'type' => 'event', 'title' => 'Deploy', 'text' => 'Revision', 'key' => 'hello.world'})
+    end
 
     assert_equal(d.instance.statsd.messages, [
       [:increment, 'hello.world1', {}],
@@ -61,7 +62,7 @@ class DogstatsdOutputTest < Test::Unit::TestCase
       [:histogram, 'hello.world', 10, {}],
       [:timing, 'hello.world', 10, {}],
       [:set, 'hello.world', 10, {}],
-      [:event, 'Deploy', 'Revision', {}],
+      [:event, 'Deploy', 'Revision', {:alert_type=>nil}],
     ])
   end
 
@@ -71,8 +72,9 @@ class DogstatsdOutputTest < Test::Unit::TestCase
 flat_tag true
     EOC
 
-    d.emit({'type' => 'increment', 'key' => 'hello.world', 'tagKey' => 'tagValue'}, Time.now.to_i)
-    d.run
+    d.run(default_tag: 'test') do
+       d.feed({'type' => 'increment', 'key' => 'hello.world', 'tagKey' => 'tagValue'})
+    end
 
     assert_equal(d.instance.statsd.messages, [
       [:increment, 'hello.world', {tags: ["tagKey:tagValue"]}],
@@ -85,13 +87,30 @@ flat_tag true
 metric_type decrement
     EOC
 
-    d.emit({'key' => 'hello.world', 'tags' => {'tagKey' => 'tagValue'}}, Time.now.to_i)
-    d.run
+    d.run(default_tag: 'test') do
+        d.feed({'key' => 'hello.world', 'tags' => {'tagKey' => 'tagValue'}})
+    end
 
     assert_equal(d.instance.statsd.messages, [
       [:decrement, 'hello.world', {tags: ["tagKey:tagValue"]}],
     ])
   end
+
+  def test_use_key_with_placeholders
+    d = create_driver(<<-EOC)
+#{default_config}
+key hello.${tag}
+    EOC
+
+    d.run(default_tag: 'dogstatsd.tag') do
+        d.feed({'type' => 'increment'})
+    end
+
+    assert_equal(d.instance.statsd.messages, [
+      [:increment, 'hello.dogstatsd.tag', {}],
+    ])
+  end
+
 
   def test_use_tag_as_key
     d = create_driver(<<-EOC)
@@ -99,8 +118,9 @@ metric_type decrement
 use_tag_as_key true
     EOC
 
-    d.emit({'type' => 'increment'}, Time.now.to_i)
-    d.run
+    d.run(default_tag: 'dogstatsd.tag') do
+        d.feed({'type' => 'increment'})
+    end
 
     assert_equal(d.instance.statsd.messages, [
       [:increment, 'dogstatsd.tag', {}],
@@ -113,8 +133,9 @@ use_tag_as_key true
 use_tag_as_key_if_missing true
     EOC
 
-    d.emit({'type' => 'increment'}, Time.now.to_i)
-    d.run
+    d.run(default_tag: 'dogstatsd.tag') do
+        d.feed({'type' => 'increment'})
+    end
 
     assert_equal(d.instance.statsd.messages, [
       [:increment, 'dogstatsd.tag', {}],
@@ -123,8 +144,9 @@ use_tag_as_key_if_missing true
 
   def test_tags
     d = create_driver
-    d.emit({'type' => 'increment', 'key' => 'hello.world', 'tags' => {'key' => 'value'}}, Time.now.to_i)
-    d.run
+    d.run(default_tag: 'dogstatsd.tag') do
+        d.feed({'type' => 'increment', 'key' => 'hello.world', 'tags' => {'key' => 'value'}})
+    end
 
     assert_equal(d.instance.statsd.messages, [
       [:increment, 'hello.world', {tags: ["key:value"]}],
@@ -137,8 +159,9 @@ use_tag_as_key_if_missing true
 sample_rate .5
     EOC
 
-    d.emit({'type' => 'increment', 'key' => 'tag'}, Time.now.to_i)
-    d.run
+    d.run(default_tag: 'dogstatsd.tag') do
+        d.feed({'type' => 'increment', 'key' => 'tag'})
+    end
 
     assert_equal(d.instance.statsd.messages, [
       [:increment, 'tag', {sample_rate: 0.5}],
@@ -147,8 +170,9 @@ sample_rate .5
 
   def test_sample_rate
     d = create_driver
-    d.emit({'type' => 'increment', 'sample_rate' => 0.5, 'key' => 'tag'}, Time.now.to_i)
-    d.run
+    d.run(default_tag: 'dogstatsd.tag') do
+        d.feed({'type' => 'increment', 'sample_rate' => 0.5, 'key' => 'tag'})
+    end
 
     assert_equal(d.instance.statsd.messages, [
       [:increment, 'tag', {sample_rate: 0.5}],
@@ -163,7 +187,7 @@ sample_rate .5
   end
 
   def create_driver(conf = default_config)
-    Fluent::Test::BufferedOutputTestDriver.new(Fluent::DogstatsdOutput, 'dogstatsd.tag').configure(conf).tap do |d|
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::DogstatsdOutput).configure(conf).tap do |d|
       d.instance.statsd = DummyStatsd.new
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
 require 'test/unit'
 require 'fluent/test'
-
+require 'fluent/test/driver/output'
+require 'datadog/statsd'


### PR DESCRIPTION
This PR adds additional features to select a key name for the metric name pushed to DogStatsd, these include:

1. Option to have a fixed key name

```haproxy
<source>
  type tail
  path /var/log/haproxy.requests.log
  pos_file /var/log/haproxy-requests.log.pos
  tag haproxy.requests
  format json
</source>

<match haproxy.requests>
  type dogstatsd
  metric_type histogram
  key haproxy.overall.response_time
  value_key response_time
  <buffer ["tag"]>
  </buffer>
</match>
```

2. Using dynamic key names implemented via implemented via `Fluent::Plugin::Output#extract_placeholders`

```haproxy
<source>
  type tail
  path /var/log/haproxy.requests.log
  pos_file /var/log/haproxy-requests.log.pos
  tag haproxy.requests
  format json
</source>

<match haproxy.requests>
  type dogstatsd
  metric_type histogram
  key haproxy.services.${service}.response_time
  value_key response_time
  <buffer ["tag", "service"]>
  </buffer>
</match>
```

The plugin is also upgraded to use the latest fluentd and dogstatsd gems.